### PR TITLE
Delay for first focus in input can be different

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,14 @@ error message. Removing it will happen instantly, and there is currently no way
 to change that.
 
 
+By default nod also waits 0.7 seconds before the first display of an error message.
+This can be configured so if the user enter an input without typing, the message takes longer to appear.
+
+```javascript
+myNod.configure({firstDelay: 1500});
+```
+
+
 
 #### Disable submit button
 

--- a/nod.js
+++ b/nod.js
@@ -481,6 +481,12 @@ nod.makeListener = function (element, mediator, triggerEvents, configuration) {
         $element;
 
     function changed (event) {
+        if(element.getAttribute('data-delay') == null) {
+            element.setAttribute('data-delay', configuration.firstDelay || 700);
+        } else {
+            element.setAttribute('data-delay', configuration.delay || 700);
+        }
+
         mediator.fire({
             id:     id,
             event:  event,
@@ -806,12 +812,16 @@ nod.makeDomNode = function (element, mediator, configuration) {
             // we use a method similar to "debouncing" the update
             clearTimeout(pendingUpdate);
 
+            var delay = parseInt(options.element.getAttribute('data-delay'));
+
             pendingUpdate = setTimeout(function () {
                 _status = status;
                 updateParent(status);
                 updateSpan(status, errorMessage);
                 pendingUpdate = null;
-            }, configuration.delay || 700);
+
+            }, delay);
+
         }
     }
 


### PR DESCRIPTION
I was asked to not display the error message for an input if the user focuses an input without typing in it.

To respond to that request, I propose that the first time nod displays an error message, it takes longer to appear than usual.
