### PR TITLE
Add errors to a specified container

### DIFF
--- a/nod.js
+++ b/nod.js
@@ -797,6 +797,7 @@ nod.makeDomNode = function (element, mediator, configuration) {
     // parent is given as a paremeter, while the span is created and added as a
     // child to the parent.
     var parent              = nod.getParent(element, configuration),
+        container           = nod.getElement(configuration.errorContainer),
         _status             = nod.constants.UNCHECKED,
         pendingUpdate       = null,
         span                = document.createElement('span'),
@@ -805,7 +806,11 @@ nod.makeDomNode = function (element, mediator, configuration) {
     span.style.display = 'none';
 
     if (!configuration.noDom) {
-        parent.appendChild(span);
+        if (container) {
+            container.appendChild(span);
+        } else {
+            parent.appendChild(span);
+        }
     }
 
     // Updates the class of the parent to match the status of the element.


### PR DESCRIPTION
I wanted to have the errors show up on a different location than what nod shows them by default. So this commit adds the ability for you to specify a container element where the errors will show. More info on the issue I have created here: https://github.com/casperin/nod/issues/125